### PR TITLE
Add wac/wace link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ This file contains a list of non-web wasm runtimes in development in no particul
 
 22. **[Asmble](https://github.com/cretz/asmble)** - Kotlin
 
+23. **[wac/wace](https://github.com/kanaka/wac)** - C
+
 ### License
 
 [![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)


### PR DESCRIPTION
wac is a small C wasm interpreter that can run plain wasm modules. wace adds support for emscripten style wasm modules (including native SDL support).